### PR TITLE
Make Vector2 and Vector3 non-abstract

### DIFF
--- a/src/FRP/Yampa/Vector2.hs
+++ b/src/FRP/Yampa/Vector2.hs
@@ -16,7 +16,7 @@
 
 module FRP.Yampa.Vector2 (
     -- module AFRPVectorSpace,
-    Vector2,            -- Abstract, instance of VectorSpace
+    Vector2(..),        -- Non-abstract, instance of VectorSpace
     vector2,            -- :: RealFloat a => a -> a -> Vector2 a
     vector2X,           -- :: RealFloat a => Vector2 a -> a
     vector2Y,           -- :: RealFloat a => Vector2 a -> a

--- a/src/FRP/Yampa/Vector3.hs
+++ b/src/FRP/Yampa/Vector3.hs
@@ -16,7 +16,7 @@
 
 module FRP.Yampa.Vector3 (
     -- module AFRPVectorSpace,
-    Vector3,            -- Abstract, instance of VectorSpace
+    Vector3(..),        -- Non-abstract, instance of VectorSpace
     vector3,            -- :: RealFloat a => a -> a -> a -> Vector3 a
     vector3X,           -- :: RealFloat a => Vector3 a -> a
     vector3Y,           -- :: RealFloat a => Vector3 a -> a


### PR DESCRIPTION
This is needed in order to allow pattern matching and to stay consistent
with `Point2`/`Point3`.

I couldn't find a reason for which Vector{2,3} should remain abstract.
If there is such, I would highly appreciate an explanation.