### PR TITLE
Ensure that strip command is present when using nix

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
 resolver: ghc-8.0.2
 extra-deps:
   - random-1.1
+
+nix:
+    packages: [binutils]


### PR DESCRIPTION
When run with the `--nix` flag this ensures that the `strip` command is present in the used `nix-shell`