### PR TITLE
Simplify travis file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ before_install:
   - travis_retry sudo apt-get install libcwiid-dev libsdl1.2-dev
 
 install:
-  - cabal install -fexample --only-dependencies --enable-tests
+  - cabal install -fexamples --only-dependencies --enable-tests
 
 script:
-  - configure -fexample --enable-tests && cabal build && cabal test
+  - configure -fexamples --enable-tests && cabal build && cabal test
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,16 @@ ghc:
   - "7.10.3"
   - "8.0.1"
 
+before_install:
+  - travis_retry sudo apt-get update
+  - travis_retry sudo apt-get install libcwiid-dev libsdl1.2-dev
+
+install:
+  - cabal install -fexample --only-dependencies --enable-tests
+
+script:
+  - configure -fexample --enable-tests && cabal build && cabal test
+
 branches:
     only:
           - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,13 @@
 # The following enables several GHC versions to be tested; often it's enough to
 # test only against the last release in a major GHC version. Feel free to omit
 # lines listings versions you don't need/want testing for.
-language: c
-env:
- - GHCVER=7.6.3
- - GHCVER=7.8.4
- - GHCVER=7.10.3
- - GHCVER=8.0.1
+language: haskell
 
-# Note: the distinction between `before_install` and `install` is not important.
-before_install:
- - unset CC
-install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-1.24 ghc-$GHCVER-prof ghc-$GHCVER-dyn alex-3.1.4 happy-1.19.5 libcwiid-dev libsdl1.2-dev
- - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/1.24/bin:/opt/alex/3.1.4/bin:/opt/happy/1.19.5/bin:$PATH
- - travis_retry cabal update
-
-script:
- - travis_retry cabal install --run-tests -fexamples -v -j1
-
-notifications:
- email: true
+ghc:
+  - "7.6.3"
+  - "7.8.4"
+  - "7.10.3"
+  - "8.0.1"
 
 branches:
     only:
@@ -35,4 +20,4 @@ deploy:
     secure: oRt7gkgOkSVwrgDVpl6uqUr9FHmAWdBR3sJje2qWqioWbOCX40fNxiWG+30XdE4pYwMb354y997nzNGydVMTpWbcVp8VdMJyw91xCSjWgGMwTzshR/U6OhVQOLaTmVR/Vpu4/MBX9UUcnhW+MAmgmE91O6myb9Lhj022gEvjShy/XA4101k+vNJui4k1nXyvOoS9SUGsLeUcBnTtOKowsCfuKiGXEuIIU9aHd5peHkwEsEN/bdm2ZPWgcQw6dzKBmZ/p6dxDUIV2wMgDUgajh9XbLIr4XbaSw1nLIUYmeusHAquXrSisYjOyP6ohtSl+4pxsoz4lqa2nosOb4n9/U2n0RZlY5xTaq4xkmXqQGwYvgJzJu9PDsF7x5NaLBLXmGfi86n6QLbGdUo2AMvABr0UQvbHJjmVwnRSD82GyelNiEDfCAQaL084iixSs+csA95rW8hEBe5yV6KutAJcl9L0j9DOI8XdjFaJY1y9d7q5wCsOijuXQqaB+Y2Ybo1jiz4zji0bve40yBjL/H4Gfv1XZav4IIKKb7QTGaxzNb2ktCsiNtK0ofLU3HkTQ8tXShbPq+SxqFPCfrf9Aqjcipz8E2GBOBo235VTbIMyI/JCIuue3ukWkZvvqXngF7Ha/VJpT62mGgds2Q7c9JF1PRFBiokaltvgoC7Zn1kOmhk8=
   on:
     branch: master
-    condition: "$GHCVER = 8.0.1"
+    condition: ${TRAVIS_HASKELL_VERSION}=8.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ before_install:
   - travis_retry sudo apt-get install libcwiid-dev libsdl1.2-dev
 
 install:
-  - cabal install -fexamples --only-dependencies --enable-tests
+  - travis_retry cabal install -fexamples --only-dependencies --enable-tests
 
 script:
-  - configure -fexamples --enable-tests && cabal build && cabal test
+  - travis_retry cabal configure -fexamples --enable-tests && cabal build && cabal test
 
 branches:
     only:


### PR DESCRIPTION
Travis now uses the standard building image for Haskell.

Closes #44.