### PR TITLE
Tests import Event from FRP.Yampa.Event instead of FRP.Yampa.Internals

### DIFF
--- a/tests/AFRPTestsAccum.hs
+++ b/tests/AFRPTestsAccum.hs
@@ -25,7 +25,7 @@ module AFRPTestsAccum (
 import Data.Maybe (fromJust)
 
 import FRP.Yampa
-import FRP.Yampa.Internals (Event(NoEvent, Event))
+import FRP.Yampa.Event (Event(NoEvent, Event))
 
 import AFRPTestsCommon
 

--- a/tests/AFRPTestsEvSrc.hs
+++ b/tests/AFRPTestsEvSrc.hs
@@ -15,7 +15,7 @@
 module AFRPTestsEvSrc (evsrc_trs, evsrc_tr) where
 
 import FRP.Yampa
-import FRP.Yampa.Internals (Event(NoEvent, Event))
+import FRP.Yampa.Event (Event(NoEvent, Event))
 
 import AFRPTestsCommon
 

--- a/tests/AFRPTestsPSwitch.hs
+++ b/tests/AFRPTestsPSwitch.hs
@@ -24,7 +24,7 @@ module AFRPTestsPSwitch (
 import Data.List (findIndex)
 
 import FRP.Yampa
-import FRP.Yampa.Internals (Event(NoEvent, Event))
+import FRP.Yampa.Event (Event(NoEvent, Event))
 
 import AFRPTestsCommon
 

--- a/tests/AFRPTestsRPSwitch.hs
+++ b/tests/AFRPTestsRPSwitch.hs
@@ -23,7 +23,7 @@ import Data.Maybe (fromJust)
 import Data.List (findIndex)
 
 import FRP.Yampa
-import FRP.Yampa.Internals (Event(NoEvent, Event))
+import FRP.Yampa.Event (Event(NoEvent, Event))
 
 import AFRPTestsCommon
 

--- a/tests/AFRPTestsRSwitch.hs
+++ b/tests/AFRPTestsRSwitch.hs
@@ -22,7 +22,7 @@ module AFRPTestsRSwitch (
 import Data.Maybe (fromJust)
 
 import FRP.Yampa
-import FRP.Yampa.Internals (Event(NoEvent, Event))
+import FRP.Yampa.Event (Event(NoEvent, Event))
 
 import AFRPTestsCommon
 

--- a/tests/AFRPTestsSwitch.hs
+++ b/tests/AFRPTestsSwitch.hs
@@ -15,7 +15,7 @@ module AFRPTestsSwitch (switch_tr, switch_trs) where
 
 import FRP.Yampa
 import FRP.Yampa.EventS
-import FRP.Yampa.Internals (Event(NoEvent, Event))
+import FRP.Yampa.Event (Event(NoEvent, Event))
 
 import AFRPTestsCommon
 

--- a/tests/AFRPTestsUtils.hs
+++ b/tests/AFRPTestsUtils.hs
@@ -17,7 +17,7 @@
 module AFRPTestsUtils (utils_tr, utils_trs) where
 
 import FRP.Yampa
-import FRP.Yampa.Internals (Event(NoEvent, Event))
+import FRP.Yampa.Event (Event(NoEvent, Event))
 import FRP.Yampa.Conditional
 import FRP.Yampa.Integration
 import FRP.Yampa.EventS

--- a/tests/AFRPTestsWFG.hs
+++ b/tests/AFRPTestsWFG.hs
@@ -15,7 +15,7 @@
 module AFRPTestsWFG (wfg_tr, wfg_trs) where
 
 import FRP.Yampa
-import FRP.Yampa.Internals (Event(NoEvent, Event))
+import FRP.Yampa.Event (Event(NoEvent, Event))
 
 import AFRPTestsCommon
 


### PR DESCRIPTION
Hey Ivan,

This is for Issue 74.

Saw your pre-release announcement in the Facebook group.  Looks like you're offering Haskell beginners a chance to get their feet wet. I'm still working through the book, but this was an easy one.

Nice to "meet" you!