### PR TITLE
List publications related to Yampa #85

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For a list of Yampa-related papers, see:
 * [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896)( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson, 2016)
 * [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)(Author: Ivan Perez, 2014 )
 * [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595)(Authors: Neil Sculthorpe and Henrik Nilsson,2009)
-* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf)(Authors: George Giorgidze and Henrik Nilsson ,2008)
+* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf)(Authors: George Giorgidze and Henrik Nilsson, 2008)
 * [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596)(Authors: George Giorgidze and Henrik Nilsson, 2007)
 * [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598)(Author: Henrik Nilsson, 2005)
 * [The Yampa Arcade](http://dl.acm.org/authorize?N08599)(Authors: Antony Courtney and Henrik Nilsson and John Peterson, 2003 )

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 
 ## Papers and technical reports
 
-For a list of Yampa-related papers, see:
 
 * [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Ivan Perez and Henrik Nilsson, 2017)
 * [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896) (Ivan Perez, Manuel Bärenz, and Henrik Nilsson, 2016)

--- a/README.md
+++ b/README.md
@@ -92,15 +92,16 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 
 For a list of Yampa-related papers, see:
 
-* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Authors: Ivan Perez and Henrik Nilsson, ICFP 2017 Oxford, UK)
-* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896)( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)
-* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)(Author: Ivan Perez )
-* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595)(Authors: Neil Sculthorpe and Henrik Nilsson)
-* [Switched-on Yampa: Programming Modular Synthesizers in Haskell](http://dl.acm.org/authorize?N08596)(Athors: George Giorgidze and Henrik Nilsson)
-* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598)(Author: Henrik Nilsson)
-* [The Yampa Arcade](http://dl.acm.org/authorize?N08599)(Authors: Antony Courtney and Henrik Nilsson and John Peterson )
-* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592)(Authors: Henrik Nilsson, Antony Courtney, and John Peterson)
-* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson.)
+* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Authors: Ivan Perez and Henrik Nilsson, 2017)
+* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896)( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson, 2016)
+* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)(Author: Ivan Perez, 2014 )
+* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595)(Authors: Neil Sculthorpe and Henrik Nilsson,2009)
+* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf)(Authors: George Giorgidze and Henrik Nilsson ,2008)
+* [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596)(Authors: George Giorgidze and Henrik Nilsson, 2007)
+* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598)(Author: Henrik Nilsson, 2005)
+* [The Yampa Arcade](http://dl.acm.org/authorize?N08599)(Authors: Antony Courtney and Henrik Nilsson and John Peterson, 2003 )
+* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson, 2002,2003)
+* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592)(Authors: Henrik Nilsson, Antony Courtney, and John Peterson, 2002)
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -94,16 +94,34 @@ For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
 * [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
-  * Authors: Ivan Perez and Henrik Nilsson
-  * Year : 
+  ######* Authors: Ivan Perez and Henrik Nilsson
+  ######* Year : 
 * [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
+  ######* Authors : 
+  ######* Year    :
+
 * [First Year PhD Report(Author: Ivan Perez )](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
+  ######* Authors :                             
+  ######* Year    :
+
 * [Safe Functional Reactive Programming through Dependent Types(Authors: Neil Sculthorpe and Henrik Nilsson)](http://dl.acm.org/authorize?N08595)
+  ######* Authors :                             
+  ######* Year    :
 * [Switched-on Yampa: Programming Modular Synthesizers in Haskell(Athors: George Giorgidze and Henrik Nilsson)](http://dl.acm.org/authorize?N08596)
+  ######* Authors :                             
+  ######* Year    :
 * [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types(Author: Henrik Nilsson)](http://dl.acm.org/authorize?N08598)
+  ######* Authors :                             
+  ######* Year    :
 * [The Yampa Arcade(Authors: Antony Courtney and Henrik Nilsson and John Peterson )](http://dl.acm.org/authorize?N08599)
+  ######* Authors :                             
+  ######* Year    :
 * [Functional reactive programming, continued(Authors: Henrik Nilsson, Antony Courtney, and John Peterson)](http://dl.acm.org/authorize?N08592)
+  ######* Authors :                             
+  ######* Year    :
 * [Arrows, robots, and functional reactive programming(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson.)](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)
+  ######* Authors :                             
+  ######* Year    :
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -93,14 +93,16 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 
 * [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Ivan Perez and Henrik Nilsson, 2017)
 * [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896) (Ivan Perez, Manuel Bärenz, and Henrik Nilsson, 2016)
-* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf) (Ivan Perez, 2014 )
+* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf) (Ivan Perez, 2014)
 * [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595) (Neil Sculthorpe and Henrik Nilsson, 2009)
+* [Push-Pull Functional Reactive Programming](http://conal.net/papers/push-pull-frp/push-pull-frp.pdf) (Conal Elliott, 2009)
 * [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf) (George Giorgidze and Henrik Nilsson, 2008)
 * [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596) (George Giorgidze and Henrik Nilsson, 2007)
 * [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598) (Henrik Nilsson, 2005)
-* [The Yampa Arcade](http://dl.acm.org/authorize?N08599) (Antony Courtney, Henrik Nilsson, and John Peterson, 2003 )
+* [The Yampa Arcade](http://dl.acm.org/authorize?N08599) (Antony Courtney, Henrik Nilsson, and John Peterson, 2003)
 * [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf) (Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson, 2002)
 * [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592) (Henrik Nilsson, Antony Courtney, and John Peterson, 2002)
+* [Genuinely Functional User Interfaces](http://conal.net/papers/genuinely-functional-guis.pdf) (Antony Courtney and Conal Elliott)
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -90,22 +90,24 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 
 ## Papers and technical reports
 
-
-* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Ivan Perez and Henrik Nilsson, 2017)
-* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896) (Ivan Perez, Manuel Bärenz, and Henrik Nilsson, 2016)
-* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf) (Ivan Perez, 2014)
-* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595) (Neil Sculthorpe and Henrik Nilsson, 2009)
-* [Push-Pull Functional Reactive Programming](http://conal.net/papers/push-pull-frp/push-pull-frp.pdf) (Conal Elliott, 2009)
-* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf) (George Giorgidze and Henrik Nilsson, 2008)
-* [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596) (George Giorgidze and Henrik Nilsson, 2007)
-* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598) (Henrik Nilsson, 2005)
+* [Extensible and Robust Functional Reactive Programming](http://www.cs.nott.ac.uk/~psxip1/papers/2017-Perez-thesis-latest.pdf) (Ivan Perez; 2017)
+* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Ivan Perez and Henrik Nilsson; 2017)
+* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896) (Ivan Perez, Manuel Bärenz, and Henrik Nilsson; 2016)
+* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595) (Neil Sculthorpe and Henrik Nilsson; 2009)
+* [Push-Pull Functional Reactive Programming](http://conal.net/papers/push-pull-frp/push-pull-frp.pdf) (Conal Elliott; 2009)
+* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf) (George Giorgidze and Henrik Nilsson; 2008)
+* [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell](http://dl.acm.org/authorize?N08596) (George Giorgidze and Henrik Nilsson; 2007)
+* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598) (Henrik Nilsson; 2005)
 * [The Yampa Arcade](http://dl.acm.org/authorize?N08599) (Antony Courtney, Henrik Nilsson, and John Peterson, 2003)
-* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf) (Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson, 2002)
-* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592) (Henrik Nilsson, Antony Courtney, and John Peterson, 2002)
-* [Genuinely Functional User Interfaces](http://conal.net/papers/genuinely-functional-guis.pdf) (Antony Courtney and Conal Elliott)
+* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf) (Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson; 2002)
+* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592) (Henrik Nilsson, Antony Courtney, and John Peterson; 2002)
+* [Genuinely Functional User Interfaces](http://conal.net/papers/genuinely-functional-guis.pdf) (Antony Courtney and Conal Elliott; 2001)
 
-See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
-which includes a review of FRP and outlines some existing issues.
+
+* See also:
+  * [Henrik Nilsson's publications](http://www.cs.nott.ac.uk/~psznhn/papers.html)
+  * [Ivan Perez's publications ](http://www.cs.nott.ac.uk/~psxip1/)
+  * [Chapter 3 of Ivan Perez's PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
 
 ## Help and collaboration
 

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 For a list of Yampa-related papers, see:
 
 * [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Authors: Ivan Perez and Henrik Nilsson, ICFP 2017 Oxford, UK)
-* [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
-* [First Year PhD Report(Author: Ivan Perez )](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
-* [Safe Functional Reactive Programming through Dependent Types(Authors: Neil Sculthorpe and Henrik Nilsson)](http://dl.acm.org/authorize?N08595)
-* [Switched-on Yampa: Programming Modular Synthesizers in Haskell(Athors: George Giorgidze and Henrik Nilsson)](http://dl.acm.org/authorize?N08596)
-* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types(Author: Henrik Nilsson)](http://dl.acm.org/authorize?N08598)
-* [The Yampa Arcade(Authors: Antony Courtney and Henrik Nilsson and John Peterson )](http://dl.acm.org/authorize?N08599)
-* [Functional reactive programming, continued(Authors: Henrik Nilsson, Antony Courtney, and John Peterson)](http://dl.acm.org/authorize?N08592)
-* [Arrows, robots, and functional reactive programming(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson.)](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)
+* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896)( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)
+* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)(Author: Ivan Perez )
+* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595)(Authors: Neil Sculthorpe and Henrik Nilsson)
+* [Switched-on Yampa: Programming Modular Synthesizers in Haskell](http://dl.acm.org/authorize?N08596)(Athors: George Giorgidze and Henrik Nilsson)
+* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598)(Author: Henrik Nilsson)
+* [The Yampa Arcade](http://dl.acm.org/authorize?N08599)(Authors: Antony Courtney and Henrik Nilsson and John Peterson )
+* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592)(Authors: Henrik Nilsson, Antony Courtney, and John Peterson)
+* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson.)
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -94,34 +94,34 @@ For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
 * [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
-  *###### Authors: Ivan Perez and Henrik Nilsson
-  *###### Year : 
+  ###### Authors: Ivan Perez and Henrik Nilsson
+  ###### Year : 
 * [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
-  *###### Authors : 
-  *###### Year    :
+  ###### Authors : 
+  ###### Year    :
 
 * [First Year PhD Report(Author: Ivan Perez )](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
-  ######* Authors :                             
-  ######* Year    :
+  ###### Authors :                             
+  ###### Year    :
 
 * [Safe Functional Reactive Programming through Dependent Types(Authors: Neil Sculthorpe and Henrik Nilsson)](http://dl.acm.org/authorize?N08595)
-  ######* Authors :                             
-  ######* Year    :
+  ###### Authors :                             
+  ###### Year    :
 * [Switched-on Yampa: Programming Modular Synthesizers in Haskell(Athors: George Giorgidze and Henrik Nilsson)](http://dl.acm.org/authorize?N08596)
-  ######* Authors :                             
-  ######* Year    :
+  ###### Authors :                             
+  ###### Year    :
 * [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types(Author: Henrik Nilsson)](http://dl.acm.org/authorize?N08598)
-  ######* Authors :                             
-  ######* Year    :
+  ###### Authors :                             
+  ###### Year    :
 * [The Yampa Arcade(Authors: Antony Courtney and Henrik Nilsson and John Peterson )](http://dl.acm.org/authorize?N08599)
-  ######* Authors :                             
-  ######* Year    :
+  ###### Authors :                             
+  ###### Year    :
 * [Functional reactive programming, continued(Authors: Henrik Nilsson, Antony Courtney, and John Peterson)](http://dl.acm.org/authorize?N08592)
-  ######* Authors :                             
-  ######* Year    :
+  ###### Authors :                             
+  ###### Year    :
 * [Arrows, robots, and functional reactive programming(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson.)](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)
-  ######* Authors :                             
-  ######* Year    :
+  ###### Authors :                             
+  ###### Year    :
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
 * [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
-  ######* Authors: Ivan Perez and Henrik Nilsson
-  ######* Year : 
+  *###### Authors: Ivan Perez and Henrik Nilsson
+  *###### Year : 
 * [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
-  ######* Authors : 
-  ######* Year    :
+  *###### Authors : 
+  *###### Year    :
 
 * [First Year PhD Report(Author: Ivan Perez )](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
   ######* Authors :                             

--- a/README.md
+++ b/README.md
@@ -92,16 +92,16 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 
 For a list of Yampa-related papers, see:
 
-* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Authors: Ivan Perez and Henrik Nilsson, 2017)
-* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896)( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson, 2016)
-* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)(Author: Ivan Perez, 2014 )
-* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595)(Authors: Neil Sculthorpe and Henrik Nilsson,2009)
-* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf)(Authors: George Giorgidze and Henrik Nilsson, 2008)
-* [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596)(Authors: George Giorgidze and Henrik Nilsson, 2007)
-* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598)(Author: Henrik Nilsson, 2005)
-* [The Yampa Arcade](http://dl.acm.org/authorize?N08599)(Authors: Antony Courtney and Henrik Nilsson and John Peterson, 2003 )
-* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson, 2002,2003)
-* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592)(Authors: Henrik Nilsson, Antony Courtney, and John Peterson, 2002)
+* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Ivan Perez and Henrik Nilsson, 2017)
+* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896)(Ivan Perez, Manuel Bärenz and Henrik Nilsson, 2016)
+* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)(Ivan Perez, 2014 )
+* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595)(Neil Sculthorpe and Henrik Nilsson, 2009)
+* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf)(George Giorgidze and Henrik Nilsson, 2008)
+* [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596)(George Giorgidze and Henrik Nilsson, 2007)
+* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598)(Henrik Nilsson, 2005)
+* [The Yampa Arcade](http://dl.acm.org/authorize?N08599)(Antony Courtney and Henrik Nilsson and John Peterson, 2003 )
+* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)(Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson, 2002)
+* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592)(Henrik Nilsson, Antony Courtney, and John Peterson, 2002)
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 For a list of Yampa-related papers, see:
 
 * [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Ivan Perez and Henrik Nilsson, 2017)
-* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896) (Ivan Perez, Manuel Bärenz and Henrik Nilsson, 2016)
+* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896) (Ivan Perez, Manuel Bärenz, and Henrik Nilsson, 2016)
 * [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf) (Ivan Perez, 2014 )
 * [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595) (Neil Sculthorpe and Henrik Nilsson, 2009)
 * [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf) (George Giorgidze and Henrik Nilsson, 2008)
 * [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596) (George Giorgidze and Henrik Nilsson, 2007)
 * [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598) (Henrik Nilsson, 2005)
-* [The Yampa Arcade](http://dl.acm.org/authorize?N08599) (Antony Courtney and Henrik Nilsson and John Peterson, 2003 )
+* [The Yampa Arcade](http://dl.acm.org/authorize?N08599) (Antony Courtney, Henrik Nilsson, and John Peterson, 2003 )
 * [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf) (Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson, 2002)
 * [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592) (Henrik Nilsson, Antony Courtney, and John Peterson, 2002)
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,8 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 
 For a list of Yampa-related papers, see:
 
-* http://www.cs.nott.ac.uk/~nhn/papers.html
-* [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
-  ###### Authors: Ivan Perez and Henrik Nilsson
-  ###### Year : 
+* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564): Authors: Ivan Perez and Henrik Nilsson, CFP 2017 (Oxford, UK)
+
 * [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
   ###### Authors : 
   ###### Year    :

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
-* item 1
-* item 2
-* item 3
-* item 4
+** [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
+** item 2
+** item 3
+** item 4
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
 * [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
+ * Authors: Ivan Perez and Henrik Nilsson
+ * Year : 
 * [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
 * [First Year PhD Report(Author: Ivan Perez )](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
 * [Safe Functional Reactive Programming through Dependent Types(Authors: Neil Sculthorpe and Henrik Nilsson)](http://dl.acm.org/authorize?N08595)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
+* item 1
+* item 2
+* item 3
+* item 4
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
 * [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
- * Authors: Ivan Perez and Henrik Nilsson
- * Year : 
+  * Authors: Ivan Perez and Henrik Nilsson
+  * Year : 
 * [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
 * [First Year PhD Report(Author: Ivan Perez )](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
 * [Safe Functional Reactive Programming through Dependent Types(Authors: Neil Sculthorpe and Henrik Nilsson)](http://dl.acm.org/authorize?N08595)

--- a/README.md
+++ b/README.md
@@ -92,34 +92,15 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 
 For a list of Yampa-related papers, see:
 
-* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564): Authors: Ivan Perez and Henrik Nilsson, CFP 2017 (Oxford, UK)
-
+* [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Authors: Ivan Perez and Henrik Nilsson, ICFP 2017 Oxford, UK)
 * [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
-  ###### Authors : 
-  ###### Year    :
-
 * [First Year PhD Report(Author: Ivan Perez )](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
-  ###### Authors :                             
-  ###### Year    :
-
 * [Safe Functional Reactive Programming through Dependent Types(Authors: Neil Sculthorpe and Henrik Nilsson)](http://dl.acm.org/authorize?N08595)
-  ###### Authors :                             
-  ###### Year    :
 * [Switched-on Yampa: Programming Modular Synthesizers in Haskell(Athors: George Giorgidze and Henrik Nilsson)](http://dl.acm.org/authorize?N08596)
-  ###### Authors :                             
-  ###### Year    :
 * [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types(Author: Henrik Nilsson)](http://dl.acm.org/authorize?N08598)
-  ###### Authors :                             
-  ###### Year    :
 * [The Yampa Arcade(Authors: Antony Courtney and Henrik Nilsson and John Peterson )](http://dl.acm.org/authorize?N08599)
-  ###### Authors :                             
-  ###### Year    :
 * [Functional reactive programming, continued(Authors: Henrik Nilsson, Antony Courtney, and John Peterson)](http://dl.acm.org/authorize?N08592)
-  ###### Authors :                             
-  ###### Year    :
 * [Arrows, robots, and functional reactive programming(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson.)](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)
-  ###### Authors :                             
-  ###### Year    :
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
-** [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
-** item 2
-** item 3
-** item 4
+* [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
+* item 2
+* item 3
+* item 4
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ Documentation is also available online: https://wiki.haskell.org/Yampa
 For a list of Yampa-related papers, see:
 
 * [Testing and Debugging Functional Reactive Programming](http://dl.acm.org/authorize?N46564) (Ivan Perez and Henrik Nilsson, 2017)
-* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896)(Ivan Perez, Manuel Bärenz and Henrik Nilsson, 2016)
-* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)(Ivan Perez, 2014 )
-* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595)(Neil Sculthorpe and Henrik Nilsson, 2009)
-* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf)(George Giorgidze and Henrik Nilsson, 2008)
-* [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596)(George Giorgidze and Henrik Nilsson, 2007)
-* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598)(Henrik Nilsson, 2005)
-* [The Yampa Arcade](http://dl.acm.org/authorize?N08599)(Antony Courtney and Henrik Nilsson and John Peterson, 2003 )
-* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)(Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson, 2002)
-* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592)(Henrik Nilsson, Antony Courtney, and John Peterson, 2002)
+* [Functional Reactive Programming, Refactored](http://dl.acm.org/authorize?N34896) (Ivan Perez, Manuel Bärenz and Henrik Nilsson, 2016)
+* [First Year PhD Report](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf) (Ivan Perez, 2014 )
+* [Safe Functional Reactive Programming through Dependent Types](http://dl.acm.org/authorize?N08595) (Neil Sculthorpe and Henrik Nilsson, 2009)
+* [Switched-on Yampa: Declarative programming of modular synthesizers](http://www.cs.nott.ac.uk/~psznhn/Publications/padl2008.pdf) (George Giorgidze and Henrik Nilsson, 2008)
+* [Demo-outline: Switched-on Yampa: Programming Modular Synthesizers in Haskell.](http://dl.acm.org/authorize?N08596) (George Giorgidze and Henrik Nilsson, 2007)
+* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types](http://dl.acm.org/authorize?N08598) (Henrik Nilsson, 2005)
+* [The Yampa Arcade](http://dl.acm.org/authorize?N08599) (Antony Courtney and Henrik Nilsson and John Peterson, 2003 )
+* [Arrows, robots, and functional reactive programming](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf) (Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson, 2002)
+* [Functional reactive programming, continued](http://dl.acm.org/authorize?N08592) (Henrik Nilsson, Antony Courtney, and John Peterson, 2002)
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.

--- a/README.md
+++ b/README.md
@@ -94,9 +94,14 @@ For a list of Yampa-related papers, see:
 
 * http://www.cs.nott.ac.uk/~nhn/papers.html
 * [Testing and Debugging Functional Reactive Programming(Authors: Ivan Perez and Henrik Nilsson)](http://dl.acm.org/authorize?N46564)
-* item 2
-* item 3
-* item 4
+* [Functional Reactive Programming, Refactored( Authors: Ivan Perez, Manuel Bärenz and Henrik Nilsson)](http://dl.acm.org/authorize?N34896)
+* [First Year PhD Report(Author: Ivan Perez )](http://www.cs.nott.ac.uk/~psxip1/papers/2014-Perez-1st-year-report.pdf)
+* [Safe Functional Reactive Programming through Dependent Types(Authors: Neil Sculthorpe and Henrik Nilsson)](http://dl.acm.org/authorize?N08595)
+* [Switched-on Yampa: Programming Modular Synthesizers in Haskell(Athors: George Giorgidze and Henrik Nilsson)](http://dl.acm.org/authorize?N08596)
+* [Dynamic Optimization for Functional Reactive Programming using Generalized Algebraic Data Types(Author: Henrik Nilsson)](http://dl.acm.org/authorize?N08598)
+* [The Yampa Arcade(Authors: Antony Courtney and Henrik Nilsson and John Peterson )](http://dl.acm.org/authorize?N08599)
+* [Functional reactive programming, continued(Authors: Henrik Nilsson, Antony Courtney, and John Peterson)](http://dl.acm.org/authorize?N08592)
+* [Arrows, robots, and functional reactive programming(Authors: Paul Hudak, Antony Courtney, Henrik Nilsson, and John Peterson.)](http://www.cs.nott.ac.uk/~psznhn/Publications/afp2002.pdf)
 
 See also PhD technical report, chapter 3. http://www.cs.nott.ac.uk/~ixp/
 which includes a review of FRP and outlines some existing issues.


### PR DESCRIPTION
issue #85 
To fix this issue I modified the following section: https://github.com/tresormuta/Yampa#documentation-and-tutorials of README.md file by listing papers about Yampa  and their direct download link.
In this list, papers are sorted by date from most recent to least recent, and are associated to their authors. 