### PR TITLE
Update stack dependencies

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,8 @@
-resolver: ghc-8.0.2
+resolver: lts-12.16
+
 extra-deps:
   - random-1.1
+  - simple-affine-space-0.1
 
 nix:
     packages: [binutils]


### PR DESCRIPTION
Make stack understand new dependency, and move to latest LTS from stackage builds with 8.4.4. If you want to have CI/CD for multiple GHC versions than you'll need to have multiple stack files with appropriate resolver set. 