### PR TITLE
Allow building with GHC 8.8

### DIFF
--- a/Yampa.cabal
+++ b/Yampa.cabal
@@ -79,6 +79,8 @@ library
   hs-source-dirs:  src
   ghc-options : -O3 -Wall -fno-warn-name-shadowing
   build-Depends: base < 6, random, deepseq, simple-affine-space
+  if !impl(ghc>=8.0)
+    build-Depends: fail == 4.9.*
   exposed-modules:
     -- Main FRP modules
     FRP.Yampa

--- a/src/FRP/Yampa/Event.hs
+++ b/src/FRP/Yampa/Event.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 -----------------------------------------------------------------------------------------
 -- |
@@ -90,6 +91,7 @@ module FRP.Yampa.Event where
 
 import Control.Applicative
 import Control.DeepSeq (NFData(..))
+import qualified Control.Monad.Fail as Fail
 
 import FRP.Yampa.Diagnostics
 
@@ -175,9 +177,15 @@ instance Monad Event where
 
     -- | See 'pure'.
     return          = pure
+
+#if !(MIN_VERSION_base(4,13,0))
+    -- | Fail with 'NoEvent'.
+    fail            = Fail.fail
+#endif
+
+instance Fail.MonadFail Event where
     -- | Fail with 'NoEvent'.
     fail _          = NoEvent
-
 
 -- | Alternative instance
 instance Alternative Event where


### PR DESCRIPTION
`Yampa` needs some slight tweaking to adapt to the `MonadFail` proposal, which was completed in `base-4.13`.