### PR TITLE
Use tasty in yampa-test

### DIFF
--- a/extensions/testing/tests/YampaQC.hs
+++ b/extensions/testing/tests/YampaQC.hs
@@ -14,14 +14,15 @@
 -- a QuickCheck predicate, which may not be possible or compatible
 -- with out goals.
 --
-module YampaQC where
+module Main where
 
 ------------------------------------------------------------------------------
 import Data.Fixed
 
-import Distribution.TestSuite.QuickCheck
 import Test.QuickCheck
 import Test.QuickCheck.Function
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
 
 import FRP.Yampa as Yampa
 import FRP.Yampa.EventS (snap)
@@ -30,8 +31,11 @@ import FRP.Yampa.QuickCheck
 import FRP.Yampa.LTLFuture
 
 ------------------------------------------------------------------------------
-tests :: IO [Test]
-tests = return
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Yampa QC properties"
     [ testProperty "SF based on (**2) equal to SF on (^2))" prop_arr_law1
     , testProperty "Identity"                               prop_arr_id
     , testProperty "Arrow Naturality"                       prop_arr_naturality

--- a/extensions/testing/yampa-test.cabal
+++ b/extensions/testing/yampa-test.cabal
@@ -41,8 +41,8 @@ library
   default-language:    Haskell2010
 
 test-suite yampa-quicheck
-  type:        detailed-0.9
-  test-module: YampaQC
+  type:        exitcode-stdio-1.0
+  main-is:     YampaQC.hs
   ghc-options: -Wall
   default-language:    Haskell2010
 
@@ -52,6 +52,7 @@ test-suite yampa-quicheck
     random,
     Cabal >= 1.19,
     QuickCheck,
+    tasty,
+    tasty-quickcheck,
     Yampa,
-    yampa-test,
-    cabal-test-quickcheck
+    yampa-test


### PR DESCRIPTION
This allows us to get rid of the `cabal-test-quickcheck` dependency. See the discussion starting at https://github.com/ivanperez-keera/Yampa/pull/143#issuecomment-539100674.