### PR TITLE
Added notice about implementing vector space using linear

### DIFF
--- a/src/FRP/Yampa.hs
+++ b/src/FRP/Yampa.hs
@@ -74,6 +74,10 @@
 -- transform signals taking their history into account. For example, the
 -- function 'integral' integrates the input signal.
 --
+-- Yampa does not enforce the use of a particular vector space implementation,
+-- meaning you could use integral for example with other vector types like
+-- V2, V1, etc from linear, see <https://gist.github.com/walseb/1e0a0ca98aaa9469ab5da04e24f482c2 example>
+--
 -- /Execution/
 --
 -- The execution of this signal transformer with specific input can be

--- a/src/FRP/Yampa/Integration.hs
+++ b/src/FRP/Yampa/Integration.hs
@@ -18,6 +18,10 @@
 --
 -- The combinator 'iterFrom' gives enough flexibility to program your own
 -- leak-free integration and derivation SFs.
+--
+-- Yampa does not enforce the use of a particular vector space implementation,
+-- meaning you could use integral for example with other vector types like
+-- V2, V1, etc from linear, see <https://gist.github.com/walseb/1e0a0ca98aaa9469ab5da04e24f482c2 example>
 -----------------------------------------------------------------------------------------
 
 module FRP.Yampa.Integration (


### PR DESCRIPTION
As discussed ivanperez-keera/Yampa#132
I wasn't sure where to put it in `Yampa.hs` so I just put it after the only mention of `integral`