### PR TITLE
Update gitignore wrt. the gitignore project. Refs #158

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,29 @@
+# Taken from the gitignore project (https://raw.githubusercontent.com/github/gitignore/master/Haskell.gitignore)
+dist
+dist-*
 cabal-dev
-.cabal-sandbox
-cabal.sandbox.config
+*.o
+*.hi
+*.hie
 *.chi
 *.chs.h
-dist
-*.hi
-*.o
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*
+
+# Others
 tests/testAFRPMain
 .virthualenv
 SourceGraph


### PR DESCRIPTION
Update gitignore wrt. the gitignore project. Refs #158

### Problem
The file https://raw.githubusercontent.com/github/gitignore/master/Haskell.gitignore contains many more entries than the `.gitignore` file in the top dir.

This has recently started being a problem because new versions of cabal (?) generate additional files not included in that `.gitignore`.

### Solution
Updated the `.gitignore` file to merge the records taken from the gitignore project (under `Taken from the gitignore project`) with the preexisting ones (under `Others`)