### PR TITLE
Fixed Documentation Typos

### DIFF
--- a/yampa/src/FRP/Yampa/Diagnostics.hs
+++ b/yampa/src/FRP/Yampa/Diagnostics.hs
@@ -7,7 +7,7 @@
 -- Stability   :  provisional
 -- Portability :  portable
 --
--- Standarized error-reporting for Yampa
+-- Standardized error-reporting for Yampa
 module FRP.Yampa.Diagnostics where
 
 -- | Reports an error due to a violation of Yampa's preconditions/requirements.

--- a/yampa/src/FRP/Yampa/Event.hs
+++ b/yampa/src/FRP/Yampa/Event.hs
@@ -224,7 +224,7 @@ mergeEvents = foldr lMerge NoEvent
 --
 -- Traverable-based definition:
 -- catEvents :: Foldable t => t (Event a) -> Event (t a)
--- carEvents e  = if (null e) then NoEvent else (sequenceA e)
+-- catEvents e  = if (null e) then NoEvent else (sequenceA e)
 catEvents :: [Event a] -> Event [a]
 catEvents eas = case [ a | Event a <- eas ] of
                   [] -> NoEvent
@@ -260,7 +260,7 @@ mapFilterE f (Event a) = case f a of
                            Nothing -> NoEvent
                            Just b  -> Event b
 
--- | Enable/disable event occurences based on an external condition.
+-- | Enable/disable event occurrences based on an external condition.
 gate :: Event a -> Bool -> Event a
 _ `gate` False = NoEvent
 e `gate` True  = e

--- a/yampa/src/FRP/Yampa/EventS.hs
+++ b/yampa/src/FRP/Yampa/EventS.hs
@@ -215,14 +215,14 @@ delayEventCat q | q < 0     = usrErr "AFRP" "delayEventCat" "Negative delay."
                                              (x' : rxs)
 
 -- | A rising edge detector. Useful for things like detecting key presses.
--- It is initialised as /up/, meaning that events occuring at time 0 will
+-- It is initialised as /up/, meaning that events occurring at time 0 will
 -- not be detected.
 edge :: SF Bool (Event ())
 edge = iEdge True
 
 -- | A rising edge detector that can be initialized as up ('True', meaning
 --   that events occurring at time 0 will not be detected) or down
---   ('False', meaning that events ocurring at time 0 will be detected).
+--   ('False', meaning that events occurring at time 0 will be detected).
 iEdge :: Bool -> SF Bool (Event ())
 iEdge b = sscanPrim f (if b then 2 else 0) NoEvent
   where
@@ -239,7 +239,7 @@ iEdge b = sscanPrim f (if b then 2 else 0) NoEvent
 edgeTag :: a -> SF Bool (Event a)
 edgeTag a = edge >>> arr (`tag` a)
 
--- | Edge detector particularized for detecting transtitions
+-- | Edge detector particularized for detecting transitions
 --   on a 'Maybe' signal from 'Nothing' to 'Just'.
 edgeJust :: SF (Maybe a) (Event a)
 edgeJust = edgeBy isJustEdge (Just undefined)

--- a/yampa/src/FRP/Yampa/InternalCore.hs
+++ b/yampa/src/FRP/Yampa/InternalCore.hs
@@ -461,7 +461,7 @@ cpXX (SFEP _ f1 s1 bne) (SFEP _ f2 s2 cne) =
     -- the last event-processing function in the chain, it has to be
     -- remembered. Since the composite event-processing function remains
     -- constant/unchanged, the NoEvent output has to be part of the state.
-    -- An alternarive would be to make the event-processing function take
+    -- An alternative would be to make the event-processing function take
     -- an extra argument. But that is likely to make the simple case more
     -- expensive. See note at sfEP.
     f (s1, s2, cne) a =

--- a/yampa/src/FRP/Yampa/Switches.hs
+++ b/yampa/src/FRP/Yampa/Switches.hs
@@ -30,7 +30,7 @@
 -- that originally provoked the switch, you are very likely to fall into an
 -- infinite loop. In those cases, the use of 'dSwitch' or '-->' may help.
 --
--- Switches vary depending on a number of criterions:
+-- Switches vary depending on a number of criteria:
 --
 -- - /Decoupled/ vs normal switching /(d)/: when an SF is being applied and a
 -- different SF needs to be applied next, one question is which one is used

--- a/yampa/src/FRP/Yampa/Time.hs
+++ b/yampa/src/FRP/Yampa/Time.hs
@@ -16,7 +16,7 @@
 -- will count using the time of switching as the start time.
 --
 -- Take also into account that, because 'FRP.Yampa.Integration.derivative' is
--- the derivative of a signal /over time/, derivating 'localTime' will always
+-- the derivative of a signal /over time/, differentiating 'localTime' will always
 -- produce the value one (@1@). If you really, really, really need to know the
 -- time delta, and need to abandon the hybrid\/FRP abstraction, see
 -- 'FRP.Yampa.Integration.iterFrom'.


### PR DESCRIPTION
The typos for the documentation were fixed as per the suggestions.