### PR TITLE
Replaced all occurrences of 'AFRP' with 'Yampa'. Refs #223

### DIFF
--- a/yampa/src/FRP/Yampa/Delays.hs
+++ b/yampa/src/FRP/Yampa/Delays.hs
@@ -40,7 +40,7 @@ pre :: SF a a
 pre = sscanPrim f uninit uninit
   where
     f c a = Just (a, c)
-    uninit = usrErr "AFRP" "pre" "Uninitialized pre operator."
+    uninit = usrErr "Yampa" "pre" "Uninitialized pre operator."
 
 -- | Initialized delay operator.
 --
@@ -66,7 +66,7 @@ b0 `fby` sf = b0 --> sf >>> pre
 -- | Delay a signal by a fixed time 't', using the second parameter
 -- to fill in the initial 't' seconds.
 delay :: Time -> a -> SF a a
-delay q a_init | q < 0     = usrErr "AFRP" "delay" "Negative delay."
+delay q a_init | q < 0     = usrErr "Yampa" "delay" "Negative delay."
                | q == 0    = identity
                | otherwise = SF {sfTF = tf0}
   where

--- a/yampa/src/FRP/Yampa/Event.hs
+++ b/yampa/src/FRP/Yampa/Event.hs
@@ -124,7 +124,7 @@ instance NFData a => NFData (Event a) where
 
 -- * Internal utilities for event construction
 
--- These utilities are to be considered strictly internal to AFRP for the
+-- These utilities are to be considered strictly internal to Yampa for the
 -- time being.
 
 -- | Convert a maybe value into a event ('Event' is isomorphic to 'Maybe').
@@ -142,7 +142,7 @@ event _ f (Event b) = f b
 -- | Extract the value from an event. Fails if there is no event.
 fromEvent :: Event a -> a
 fromEvent (Event a) = a
-fromEvent NoEvent   = usrErr "AFRP" "fromEvent" "Not an event."
+fromEvent NoEvent   = usrErr "Yampa" "fromEvent" "Not an event."
 
 -- | Tests whether the input represents an actual event.
 isEvent :: Event a -> Bool
@@ -186,7 +186,7 @@ rMerge = flip (<|>)
 
 -- | Unbiased event merge: simultaneous occurrence is an error.
 merge :: Event a -> Event a -> Event a
-merge = mergeBy (usrErr "AFRP" "merge" "Simultaneous event occurrence.")
+merge = mergeBy (usrErr "Yampa" "merge" "Simultaneous event occurrence.")
 
 -- | Event merge parameterized by a conflict resolution function.
 --

--- a/yampa/src/FRP/Yampa/EventS.hs
+++ b/yampa/src/FRP/Yampa/EventS.hs
@@ -94,7 +94,7 @@ after q x = afterEach [(q,x)]
 -- point in time.
 repeatedly :: Time -> b -> SF a (Event b)
 repeatedly q x | q > 0 = afterEach qxs
-               | otherwise = usrErr "AFRP" "repeatedly" "Non-positive period."
+               | otherwise = usrErr "Yampa" "repeatedly" "Non-positive period."
   where
     qxs = (q,x):qxs
 
@@ -110,7 +110,7 @@ afterEach qxs = afterEachCat qxs >>> arr (fmap head)
 afterEachCat :: [(Time,b)] -> SF a (Event [b])
 afterEachCat [] = never
 afterEachCat ((q,x):qxs)
-    | q < 0     = usrErr "AFRP" "afterEachCat" "Negative period."
+    | q < 0     = usrErr "Yampa" "afterEachCat" "Negative period."
     | otherwise = SF {sfTF = tf0}
   where
     tf0 _ = if q <= 0
@@ -119,7 +119,7 @@ afterEachCat ((q,x):qxs)
 
     emitEventsScheduleNext _ xs [] = (sfNever, Event (reverse xs))
     emitEventsScheduleNext t xs ((q,x):qxs)
-        | q < 0     = usrErr "AFRP" "afterEachCat" "Negative period."
+        | q < 0     = usrErr "Yampa" "afterEachCat" "Negative period."
         | t' >= 0   = emitEventsScheduleNext t' (x:xs) qxs
         | otherwise = (awaitNextEvent t' x qxs, Event (reverse xs))
       where
@@ -133,14 +133,14 @@ afterEachCat ((q,x):qxs)
 
 -- | Delay for events. (Consider it a triggered after, hence /basic/.)
 delayEvent :: Time -> SF (Event a) (Event a)
-delayEvent q | q < 0     = usrErr "AFRP" "delayEvent" "Negative delay."
+delayEvent q | q < 0     = usrErr "Yampa" "delayEvent" "Negative delay."
              | q == 0    = identity
              | otherwise = delayEventCat q >>> arr (fmap head)
 
 -- | Delay an event by a given delta and catenate events that occur so closely
 -- so as to be /inseparable/.
 delayEventCat :: Time -> SF (Event a) (Event [a])
-delayEventCat q | q < 0     = usrErr "AFRP" "delayEventCat" "Negative delay."
+delayEventCat q | q < 0     = usrErr "Yampa" "delayEventCat" "Negative delay."
                 | q == 0    = arr (fmap (:[]))
                 | otherwise = SF {sfTF = tf0}
   where

--- a/yampa/src/FRP/Yampa/InternalCore.hs
+++ b/yampa/src/FRP/Yampa/InternalCore.hs
@@ -286,7 +286,7 @@ vfyNoEv :: Event a -> b -> b
 vfyNoEv NoEvent b = b
 vfyNoEv _       _  =
   usrErr
-    "AFRP"
+    "Yampa"
     "vfyNoEv"
     "Assertion failed: Functions on events must not map NoEvent to Event."
 
@@ -469,7 +469,7 @@ cpXX (SFEP _ f1 s1 bne) (SFEP _ f2 s2 cne) =
         (s1', NoEvent, NoEvent) -> ((s1', s2, cne), cne, cne)
         (s1', Event b, NoEvent) ->
           let (s2', c, cne') = f2 s2 b in ((s1', s2', cne'), c, cne')
-        _ -> usrErr "AFRP" "cpXX" $
+        _ -> usrErr "Yampa" "cpXX" $
                "Assertion failed: Functions on events must not map "
                ++ "NoEvent to Event."
 cpXX sf1@(SFEP{}) (SFCpAXA _ (FDE f21 f21ne) sf22 fd23) =
@@ -660,7 +660,7 @@ cpXE sf1 f2 f2ne = cpXEAux (FDE f2 f2ne) f2 f2ne sf1
           case f1 s a of
             (s', NoEvent, NoEvent) -> (s', f2ne,  f2ne)
             (s', eb,      NoEvent) -> (s', f2 eb, f2ne)
-            _ -> usrErr "AFRP" "cpXEAux" $
+            _ -> usrErr "Yampa" "cpXEAux" $
                    "Assertion failed: Functions on events must not "
                    ++ "map NoEvent to Event."
     cpXEAux fd2 _ _ (SFCpAXA _ fd11 sf12 fd13) =

--- a/yampa/src/FRP/Yampa/Random.hs
+++ b/yampa/src/FRP/Yampa/Random.hs
@@ -41,12 +41,12 @@ noiseR :: (RandomGen g, Random b) => (b,b) -> g -> SF a b
 noiseR range g0 = streamToSF (randomRs range g0)
 
 streamToSF :: [b] -> SF a b
-streamToSF []     = intErr "AFRP" "streamToSF" "Empty list!"
+streamToSF []     = intErr "Yampa" "streamToSF" "Empty list!"
 streamToSF (b:bs) = SF {sfTF = tf0}
   where
     tf0 _ = (stsfAux bs, b)
 
-    stsfAux []     = intErr "AFRP" "streamToSF" "Empty list!"
+    stsfAux []     = intErr "Yampa" "streamToSF" "Empty list!"
     -- Invarying since stsfAux [] is an error.
     stsfAux (b:bs) = SF' tf -- True
       where
@@ -60,7 +60,7 @@ streamToSF (b:bs) = SF {sfTF = tf0}
 
 occasionally :: RandomGen g => g -> Time -> b -> SF a (Event b)
 occasionally g t_avg x | t_avg > 0 = SF {sfTF = tf0}
-                       | otherwise = usrErr "AFRP" "occasionally"
+                       | otherwise = usrErr "Yampa" "occasionally"
                                             "Non-positive average interval."
   where
     -- Generally, if events occur with an average frequency of f, the

--- a/yampa/src/FRP/Yampa/Simulation.hs
+++ b/yampa/src/FRP/Yampa/Simulation.hs
@@ -185,11 +185,11 @@ embedSynch sf0 (a0, dtas) = SF {sfTF = tf0}
 
     tf0 _ = (esAux 0 (zip tts bbs), b)
 
-    esAux _       []    = intErr "AFRP" "embedSynch" "Empty list!"
+    esAux _       []    = intErr "Yampa" "embedSynch" "Empty list!"
     -- Invarying below since esAux [] is an error.
     esAux tp_prev tbtbs = SF' tf -- True
       where
-        tf dt r | r < 0     = usrErr "AFRP" "embedSynch" "Negative ratio."
+        tf dt r | r < 0     = usrErr "Yampa" "embedSynch" "Negative ratio."
                 | otherwise = let tp = tp_prev + dt * r
                                   (b, tbtbs') = advance tp tbtbs
                               in (esAux tp tbtbs', b)
@@ -208,12 +208,12 @@ embedSynch sf0 (a0, dtas) = SF {sfTF = tf0}
 --   unnecessary samples when the input has not changed since
 --   the last sample.
 deltaEncode :: Eq a => DTime -> [a] -> (a, [(DTime, Maybe a)])
-deltaEncode _  []        = usrErr "AFRP" "deltaEncode" "Empty input list."
+deltaEncode _  []        = usrErr "Yampa" "deltaEncode" "Empty input list."
 deltaEncode dt aas@(_:_) = deltaEncodeBy (==) dt aas
 
 -- | 'deltaEncode' parameterized by the equality test.
 deltaEncodeBy :: (a -> a -> Bool) -> DTime -> [a] -> (a, [(DTime, Maybe a)])
-deltaEncodeBy _  _  []      = usrErr "AFRP" "deltaEncodeBy" "Empty input list."
+deltaEncodeBy _  _  []      = usrErr "Yampa" "deltaEncodeBy" "Empty input list."
 deltaEncodeBy eq dt (a0:as) = (a0, zip (repeat dt) (debAux a0 as))
   where
     debAux _      []                     = []

--- a/yampa/src/FRP/Yampa/Task.hs
+++ b/yampa/src/FRP/Yampa/Task.hs
@@ -74,14 +74,14 @@ runTask tk = (unTask tk) (constant . Right)
 -- Convenience function for tasks which are known not to terminate.
 runTask_ :: Task a b c -> SF a b
 runTask_ tk = runTask tk
-              >>> arr (either id (usrErr "AFRPTask" "runTask_"
+              >>> arr (either id (usrErr "YampaTask" "runTask_"
                                          "Task terminated!"))
 
 -- | Creates an SF that represents an SF and produces an event
 -- when the task terminates, and otherwise produces just an output.
 taskToSF :: Task a b c -> SF a (b, Event c)
 taskToSF tk = runTask tk
-              >>> (arr (either id (usrErr "AFRPTask" "runTask_"
+              >>> (arr (either id (usrErr "YampaTask" "runTask_"
                                           "Task terminated!"))
                    &&& edgeBy isEdge (Left undefined))
   where
@@ -152,7 +152,7 @@ sleepT t b = mkTask (constant b &&& after t ())
 -- @snapT >> snapT = snapT@
 
 snapT :: Task a b a
-snapT = mkTask (constant (intErr "AFRPTask" "snapT" "Bad switch?") &&& snap)
+snapT = mkTask (constant (intErr "YampaTask" "snapT" "Bad switch?") &&& snap)
 
 -- * Basic tasks combinators
 


### PR DESCRIPTION
Replaced all occurrences of "AFRP" with "Yampa" & "AFRPTask" with "YampaTask" in error messages. 
Reference issue #223 : https://github.com/ivanperez-keera/Yampa/issues/223
